### PR TITLE
Increment build number from 0 to 1

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 217e1a86842d64dc70bcb89e341954f338b270d05fe240b02830ae50968d168f
 
 build:
-  number: 0
+  number: 1
   script:
     - go-licenses save . --save_path library_licenses
     - if: unix


### PR DESCRIPTION
Dummy commit to re-trigger failed Windows build (timeout).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
